### PR TITLE
Use a more well-defined way to accept trailing comma

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,8 @@ macro_rules! hashmap {
     (@single $($x:tt)*) => (());
     (@count $($rest:expr),*) => (<[()]>::len(&[$(hashmap!(@single $rest)),*]));
     
-    ( $($key:expr => $value:expr),* $(,)*) => {
+    ($($key:expr => $value:expr,)+) => { hashmap!($($key => $value),+) };
+    ($($key:expr => $value:expr),*) => {
         {
             let _cap = hashmap!(@count $($key),*);
             let mut _map = ::std::collections::HashMap::with_capacity(_cap);
@@ -78,7 +79,8 @@ macro_rules! hashset {
     (@single $($x:tt)*) => (());
     (@count $($rest:expr),*) => (<[()]>::len(&[$(hashset!(@single $rest)),*]));
     
-    ( $($key:expr),* $(,)*) => {
+    ($($key:expr,)+) => { hashset!($($key),+) };
+    ($($key:expr),*) => {
         {
             let _cap = hashset!(@count $($key),*);
             let mut _set = ::std::collections::HashSet::with_capacity(_cap);


### PR DESCRIPTION
See rust-lang/rust#25658
