### PR TITLE
lib: rename _map to map in macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,11 +51,11 @@ macro_rules! hashmap {
     ($($key:expr => $value:expr),*) => {
         {
             let _cap = hashmap!(@count $($key),*);
-            let mut _map = ::std::collections::HashMap::with_capacity(_cap);
+            let mut map = ::std::collections::HashMap::with_capacity(_cap);
             $(
-                _map.insert($key, $value);
+                map.insert($key, $value);
             )*
-            _map
+            map
         }
     };
 }
@@ -116,11 +116,11 @@ macro_rules! btreemap {
     
     ( $($key:expr => $value:expr),* ) => {
         {
-            let mut _map = ::std::collections::BTreeMap::new();
+            let mut map = ::std::collections::BTreeMap::new();
             $(
-                _map.insert($key, $value);
+                map.insert($key, $value);
             )*
-            _map
+            map
         }
     };
 }


### PR DESCRIPTION
This renaming fixes a warning emitted by clippy:

```
<maplit macros>:6:1: 6:5 error: used binding which is prefixed with an underscore. A leading underscore signals that a binding will not be used., #[deny(used_underscore_binding)] on by default
<maplit macros>:6 _map . insert ( $ key , $ value ) ; ) * _map } } ;
```

Signed-off-by: Tibor Benke ihrwein@gmail.com
