### PR TITLE
removed underscore prefixes - clippy complains

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,10 @@ description = "Container / collection literal macros for HashMap, HashSet, BTree
 
 keywords = ["literal", "data-structure", "hashmap", "macro"]
 
+[dependencies]
+clippy = {version = "~0.0.23", optional = true}
+
+[features]
+default = []
+dev = ["clippy"]
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![allow(unused_mut)]
 
 //! Macros for container literals with specific type.
 //! 
@@ -50,12 +51,12 @@ macro_rules! hashmap {
     ($($key:expr => $value:expr,)+) => { hashmap!($($key => $value),+) };
     ($($key:expr => $value:expr),*) => {
         {
-            let _cap = hashmap!(@count $($key),*);
-            let mut _map = ::std::collections::HashMap::with_capacity(_cap);
+            let cap = hashmap!(@count $($key),*);
+            let mut map = ::std::collections::HashMap::with_capacity(cap);
             $(
-                _map.insert($key, $value);
+                map.insert($key, $value);
             )*
-            _map
+            map
         }
     };
 }
@@ -82,8 +83,8 @@ macro_rules! hashset {
     ($($key:expr,)+) => { hashset!($($key),+) };
     ($($key:expr),*) => {
         {
-            let _cap = hashset!(@count $($key),*);
-            let mut _set = ::std::collections::HashSet::with_capacity(_cap);
+            let cap = hashset!(@count $($key),*);
+            let mut _set = ::std::collections::HashSet::with_capacity(cap);
             $(
                 _set.insert($key);
             )*
@@ -116,11 +117,11 @@ macro_rules! btreemap {
     
     ( $($key:expr => $value:expr),* ) => {
         {
-            let mut _map = ::std::collections::BTreeMap::new();
+            let mut map = ::std::collections::BTreeMap::new();
             $(
-                _map.insert($key, $value);
+                map.insert($key, $value);
             )*
-            _map
+            map
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,20 @@
-#![warn(missing_docs)]
+#![deny(missing_docs,
+        missing_copy_implementations,
+        trivial_casts, trivial_numeric_casts,
+        unsafe_code,
+        unstable_features,
+        unused_import_braces, unused_qualifications)]
+#![warn(missing_debug_implementations)]
+
 #![allow(unused_mut)]
 
+#![cfg_attr(feature = "dev", allow(unstable_features))]
+#![cfg_attr(feature = "dev", feature(plugin))]
+#![cfg_attr(feature = "dev", plugin(clippy))]
+
+
 //! Macros for container literals with specific type.
-//! 
+//!
 //! ```
 //! #[macro_use] extern crate maplit;
 //!
@@ -47,7 +59,7 @@
 macro_rules! hashmap {
     (@single $($x:tt)*) => (());
     (@count $($rest:expr),*) => (<[()]>::len(&[$(hashmap!(@single $rest)),*]));
-    
+
     ($($key:expr => $value:expr,)+) => { hashmap!($($key => $value),+) };
     ($($key:expr => $value:expr),*) => {
         {
@@ -79,7 +91,7 @@ macro_rules! hashmap {
 macro_rules! hashset {
     (@single $($x:tt)*) => (());
     (@count $($rest:expr),*) => (<[()]>::len(&[$(hashset!(@single $rest)),*]));
-    
+
     ($($key:expr,)+) => { hashset!($($key),+) };
     ($($key:expr),*) => {
         {
@@ -114,7 +126,7 @@ macro_rules! hashset {
 macro_rules! btreemap {
     // trailing comma case
     ($($key:expr => $value:expr,)+) => (btreemap!($($key => $value),+));
-    
+
     ( $($key:expr => $value:expr),* ) => {
         {
             let mut map = ::std::collections::BTreeMap::new();
@@ -143,7 +155,7 @@ macro_rules! btreemap {
 /// ```
 macro_rules! btreeset {
     ($($key:expr,)+) => (btreeset!($($key),+));
-    
+
     ( $($key:expr),* ) => {
         {
             let mut _set = ::std::collections::BTreeSet::new();
@@ -166,7 +178,7 @@ fn test_hashmap() {
     assert_eq!(names[&1], "one");
     assert_eq!(names[&2], "two");
     assert_eq!(names.get(&3), None);
-    
+
     let empty: HashMap<i32, i32> = hashmap!{};
     assert_eq!(empty.len(), 0);
 
@@ -187,7 +199,7 @@ fn test_btreemap() {
     assert_eq!(names[&1], "one");
     assert_eq!(names[&2], "two");
     assert_eq!(names.get(&3), None);
-    
+
     let empty: BTreeMap<i32, i32> = btreemap!{};
     assert_eq!(empty.len(), 0);
 


### PR DESCRIPTION
Hey, I know you just reverted the same kind of pull request. I just saw that as I pulled  before pushing my changes :confused: :smile: , bit too late.

What's different about this one is that I just added a `#[allow(unused_mut)]` instead.
You don't have to merge this, but what do you think? Clippy is just a bit picky about this dependency.

cheers
