### PR TITLE
add map keyword so its easier to find on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ documentation = "https://docs.rs/maplit/"
 
 description = "Container / collection literal macros for HashMap, HashSet, BTreeMap, BTreeSet."
 
-keywords = ["literal", "data-structure", "hashmap", "macro"]
+keywords = ["literal", "data-structure", "hashmap", "macro", "map"]
 


### PR DESCRIPTION
I recently was trying to find a macro for making maps on crates.io. This is obviously a wonderful crate, but when searching for both "map" and "map macro" I was unable to find anything like what I wanted. Had I simply typed "hashmap macro" I would have found this, but I typed "map" since that is the more generic term. I think using the 5th keyword slot for "map" is appropriate.