### PR TITLE
convert_args! for composable opt-in key/key-value conversion for maplit macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,13 @@ sudo: false
 matrix:
   include:
     - rust: 1.14.0
+    - rust: 1.20.0
     - rust: stable
     - rust: beta
     - rust: nightly
+branches:
+  only:
+    - master
 script:
   - |
       cargo build --verbose --features "$FEATURES" &&

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ macro_rules! convert_args {
     };
     ($macro_name:ident ! $($rest:tt)*) => {
         convert_args! {
-            keys=Into::into, values=Into::into,
+            keys=::std::convert::Into::into, values=::std::convert::Into::into,
             $macro_name !
             $($rest)*
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,9 +205,9 @@ pub fn id<T>(t: T) -> T { t }
 ///
 /// // c. convert_args! works with all the maplit macros -- and macros from other
 /// // crates that have the same "signature".
-/// // For example, btreeset and conversion from &str to Box<str>:
+/// // For example, btreeset and conversion from &str to Vec<u8>.
 ///
-/// let set: BTreeSet<Box<str>> = convert_args!(btreeset!(
+/// let set: BTreeSet<Vec<u8>> = convert_args!(btreeset!(
 ///     "a", "b", "c", "d", "a", "e", "f",
 /// ));
 /// assert_eq!(set.len(), 6);
@@ -217,7 +217,7 @@ pub fn id<T>(t: T) -> T { t }
 /// ```
 #[macro_export]
 macro_rules! convert_args {
-    (keys=$kf:expr, $macro_name:ident !($($k:expr)* $(,)*)) => {
+    (keys=$kf:expr, $macro_name:ident !($($k:expr),* $(,)*)) => {
         $macro_name! { $(($kf)($k)),* }
     };
     (keys=$kf:expr, values=$vf:expr, $macro_name:ident !($($k:expr),* $(,)*)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ macro_rules! btreeset {
 
 /// Identity function. Used as the fallback for conversion.
 #[doc(hidden)]
-pub fn id<T>(t: T) -> T { t }
+pub fn __id<T>(t: T) -> T { t }
 
 /// Macro that converts the keys or key-value pairs passed to another maplit
 /// macro. The default conversion is to use the [`Into`] trait, if no
@@ -228,7 +228,7 @@ macro_rules! convert_args {
     };
     (keys=$kf:expr, $macro_name:ident !($($rest:tt)*)) => {
         convert_args! {
-            keys=$kf, values=$crate::id,
+            keys=$kf, values=$crate::__id,
             $macro_name !(
                 $($rest)*
             )
@@ -236,7 +236,7 @@ macro_rules! convert_args {
     };
     (values=$vf:expr, $macro_name:ident !($($rest:tt)*)) => {
         convert_args! {
-            keys=$crate::id, values=$vf,
+            keys=$crate::__id, values=$vf,
             $macro_name !(
                 $($rest)*
             )
@@ -277,7 +277,7 @@ fn test_hashmap() {
         "two" => 2,
     ));
 
-    let _: HashMap<String, i32> = convert_args!(keys=String::from, values=id, hashmap!(
+    let _: HashMap<String, i32> = convert_args!(keys=String::from, values=__id, hashmap!(
         "one" => 1,
         "two" => 2,
     ));


### PR DESCRIPTION
Introduce a new macro for opt-in and composable key or key-value conversion for maplit macros. The macro nesting is inspired by how the `nom` crate uses macros.

Motivation behind this

- If we use `Into` conversion by default, we have type ambiguity often
- Allow opt in conversions as well as configurability
- Without having to repetitively change each maplit macro to support it!

For the rest of the description, this is the documentation of the new macro:

----

Macro that converts the keys or key-value pairs passed to another maplit
macro. The default conversion is to use the [`Into`] trait, if no
custom conversion is passed.

The syntax is:

`convert_args!(` `keys=` *function* `,` `values=` *function* `,`
    *macro_name* `!(` [ *key* => *value* [, *key* => *value* ... ] ] `))`

Here *macro_name* is any other maplit macro and either or both of the
explicit `keys=` and `values=` parameters can be omitted.

[`Into`]: https://doc.rust-lang.org/std/convert/trait.Into.html


### Examples

```rust
#[macro_use] extern crate maplit;
# fn main() {

use std::collections::HashMap;
use std::collections::BTreeSet;

// a. Use the default conversion with the Into trait.
// Here this converts both the key and value string literals to `String`,
// but we need to specify the map type exactly!

let map1: HashMap<String, String> = convert_args!(hashmap!(
    "a" => "b",
    "c" => "d",
));

// b. Specify an explicit custom conversion for the keys. If we don't specify
// a conversion for the values, they are not converted at all.

let map2 = convert_args!(keys=String::from, hashmap!(
    "a" => 1,
    "c" => 2,
));

// Note: map2 is a HashMap<String, i32>, but we didn't need to specify the type
let _: HashMap<String, i32> = map2;

// c. convert_args! works with all the maplit macros -- and macros from other
// crates that have the same "signature".
// For example, btreeset and conversion from &str to Box<str>:

let set: BTreeSet<Box<str>> = convert_args!(btreeset!(
    "a", "b", "c", "d", "a", "e", "f",
));
assert_eq!(set.len(), 6);


# }
```

Closes #12 
Closes #13