### PR TITLE
Add hashbrown feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,8 @@ description = "Collection “literal” macros for HashMap, HashSet, BTreeMap, a
 keywords = ["literal", "data-structure", "hashmap", "macro"]
 categories = ["rust-patterns"]
 
+[dependencies]
+hashbrown = { version = "0.1", optional = true }
+
 [package.metadata.release]
 no-dev-version = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![warn(missing_docs)]
 #![warn(unused_results)]
-#![doc(html_root_url="https://docs.rs/maplit/1/")]
+#![doc(html_root_url = "https://docs.rs/maplit/1/")]
 
 //! Macros for container literals with specific type.
 //!
@@ -159,6 +159,7 @@ macro_rules! btreemap {
 /// assert!(!set.contains("c"));
 /// # }
 /// ```
+
 macro_rules! btreeset {
     ($($key:expr,)+) => (btreeset!($($key),+));
 
@@ -175,7 +176,9 @@ macro_rules! btreeset {
 
 /// Identity function. Used as the fallback for conversion.
 #[doc(hidden)]
-pub fn __id<T>(t: T) -> T { t }
+pub fn __id<T>(t: T) -> T {
+    t
+}
 
 /// Macro that converts the keys or key-value pairs passed to another maplit
 /// macro. The default conversion is to use the [`Into`] trait, if no
@@ -284,7 +287,7 @@ fn test_hashmap() {
     use std::collections::HashMap;
     #[cfg(not(feature = "hashbrown"))]
     use std::collections::HashSet;
-    let names = hashmap!{
+    let names = hashmap! {
         1 => "one",
         2 => "two",
     };
@@ -293,47 +296,45 @@ fn test_hashmap() {
     assert_eq!(names[&2], "two");
     assert_eq!(names.get(&3), None);
 
-    let empty: HashMap<i32, i32> = hashmap!{};
+    let empty: HashMap<i32, i32> = hashmap! {};
     assert_eq!(empty.len(), 0);
 
-    let _nested_compiles = hashmap!{
+    let _nested_compiles = hashmap! {
         1 => hashmap!{0 => 1 + 2,},
         2 => hashmap!{1 => 1,},
     };
 
-    let _: HashMap<String, i32> = convert_args!(keys=String::from, hashmap!(
-        "one" => 1,
-        "two" => 2,
-    ));
+    let _: HashMap<String, i32> = convert_args!(
+        keys = String::from,
+        hashmap!(
+            "one" => 1,
+            "two" => 2,
+        )
+    );
 
-    let _: HashMap<String, i32> = convert_args!(keys=String::from, values=__id, hashmap!(
-        "one" => 1,
-        "two" => 2,
-    ));
+    let _: HashMap<String, i32> = convert_args!(
+        keys = String::from,
+        values = __id,
+        hashmap!(
+            "one" => 1,
+            "two" => 2,
+        )
+    );
 
-    let names: HashSet<String> = convert_args!(hashset!(
-        "one",
-        "two",
-    ));
+    let names: HashSet<String> = convert_args!(hashset!("one", "two",));
     assert!(names.contains("one"));
     assert!(names.contains("two"));
 
-    let lengths: HashSet<usize> = convert_args!(keys=str::len, hashset!(
-        "one",
-        "two",
-    ));
+    let lengths: HashSet<usize> = convert_args!(keys = str::len, hashset!("one", "two",));
     assert_eq!(lengths.len(), 1);
 
-    let _no_trailing: HashSet<usize> = convert_args!(keys=str::len, hashset!(
-        "one",
-        "two"
-    ));
+    let _no_trailing: HashSet<usize> = convert_args!(keys = str::len, hashset!("one", "two"));
 }
 
 #[test]
 fn test_btreemap() {
     use std::collections::BTreeMap;
-    let names = btreemap!{
+    let names = btreemap! {
         1 => "one",
         2 => "two",
     };
@@ -342,10 +343,10 @@ fn test_btreemap() {
     assert_eq!(names[&2], "two");
     assert_eq!(names.get(&3), None);
 
-    let empty: BTreeMap<i32, i32> = btreemap!{};
+    let empty: BTreeMap<i32, i32> = btreemap! {};
     assert_eq!(empty.len(), 0);
 
-    let _nested_compiles = btreemap!{
+    let _nested_compiles = btreemap! {
         1 => btreemap!{0 => 1 + 2,},
         2 => btreemap!{1 => 1,},
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 //!
 //! ```
 //! #[macro_use] extern crate maplit;
+//! #[cfg(feature = "hashbrown")]
+//! extern crate hashbrown;
 //!
 //! # fn main() {
 //! let map = hashmap!{
@@ -25,6 +27,9 @@
 //! Generic container macros already exist elsewhere, so those are not provided
 //! here at the moment.
 
+#[cfg(feature = "hashbrown")]
+extern crate hashbrown;
+
 #[macro_export]
 /// Create a **HashMap** from a list of key-value pairs
 ///
@@ -32,6 +37,8 @@
 ///
 /// ```
 /// #[macro_use] extern crate maplit;
+/// #[cfg(feature = "hashbrown")]
+/// extern crate hashbrown;
 /// # fn main() {
 ///
 /// let map = hashmap!{
@@ -51,6 +58,9 @@ macro_rules! hashmap {
     ($($key:expr => $value:expr),*) => {
         {
             let _cap = hashmap!(@count $($key),*);
+            #[cfg(feature = "hashbrown")]
+            let mut _map = ::hashbrown::HashMap::with_capacity(_cap);
+            #[cfg(not(feature = "hashbrown"))]
             let mut _map = ::std::collections::HashMap::with_capacity(_cap);
             $(
                 let _ = _map.insert($key, $value);
@@ -66,6 +76,8 @@ macro_rules! hashmap {
 ///
 /// ```
 /// #[macro_use] extern crate maplit;
+/// #[cfg(feature = "hashbrown")]
+/// extern crate hashbrown;
 /// # fn main() {
 ///
 /// let set = hashset!{"a", "b"};
@@ -83,6 +95,9 @@ macro_rules! hashset {
     ($($key:expr),*) => {
         {
             let _cap = hashset!(@count $($key),*);
+            #[cfg(feature = "hashbrown")]
+            let mut _set = ::hashbrown::HashSet::with_capacity(_cap);
+            #[cfg(not(feature = "hashbrown"))]
             let mut _set = ::std::collections::HashSet::with_capacity(_cap);
             $(
                 let _ = _set.insert($key);
@@ -99,6 +114,8 @@ macro_rules! hashset {
 ///
 /// ```
 /// #[macro_use] extern crate maplit;
+/// #[cfg(feature = "hashbrown")]
+/// extern crate hashbrown;
 /// # fn main() {
 ///
 /// let map = btreemap!{
@@ -132,6 +149,8 @@ macro_rules! btreemap {
 ///
 /// ```
 /// #[macro_use] extern crate maplit;
+/// #[cfg(feature = "hashbrown")]
+/// extern crate hashbrown;
 /// # fn main() {
 ///
 /// let set = btreeset!{"a", "b"};
@@ -177,8 +196,13 @@ pub fn __id<T>(t: T) -> T { t }
 ///
 /// ```
 /// #[macro_use] extern crate maplit;
+/// #[cfg(feature = "hashbrown")]
+/// extern crate hashbrown;
 /// # fn main() {
 ///
+/// #[cfg(feature = "hashbrown")]
+/// use hashbrown::HashMap;
+/// #[cfg(not(feature = "hashbrown"))]
 /// use std::collections::HashMap;
 /// use std::collections::BTreeSet;
 ///
@@ -252,7 +276,13 @@ macro_rules! convert_args {
 
 #[test]
 fn test_hashmap() {
+    #[cfg(feature = "hashbrown")]
+    use hashbrown::HashMap;
+    #[cfg(feature = "hashbrown")]
+    use hashbrown::HashSet;
+    #[cfg(not(feature = "hashbrown"))]
     use std::collections::HashMap;
+    #[cfg(not(feature = "hashbrown"))]
     use std::collections::HashSet;
     let names = hashmap!{
         1 => "one",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ extern crate hashbrown;
 /// assert_eq!(map.get("c"), None);
 /// # }
 /// ```
+#[cfg(feature = "hashbrown")]
 macro_rules! hashmap {
     (@single $($x:tt)*) => (());
     (@count $($rest:expr),*) => (<[()]>::len(&[$(hashmap!(@single $rest)),*]));
@@ -58,14 +59,29 @@ macro_rules! hashmap {
     ($($key:expr => $value:expr),*) => {
         {
             let _cap = hashmap!(@count $($key),*);
-            #[cfg(feature = "hashbrown")]
             let mut _map = ::hashbrown::HashMap::with_capacity(_cap);
-            #[cfg(not(feature = "hashbrown"))]
-            let mut _map = ::std::collections::HashMap::with_capacity(_cap);
             $(
                 let _ = _map.insert($key, $value);
             )*
             _map
+        }
+    };
+}
+
+#[cfg(not(feature = "hashbrown"))]
+macro_rules! hashmap {
+    (@single $($x:tt)*) => (());
+    (@count $($rest:expr),*) => (<[()]>::len(&[$(hashmap!(@single $rest)),*]));
+
+    ($($key:expr => $value:expr,)+) => { hashmap!($($key => $value),+) };
+    ($($key:expr => $value:expr),*) => {
+        {
+            let _cap = hashmap!(@count $($key),*);
+            let mut _map = ::std::collections::HashMap::with_capacity(_cap);
+            $(
+                let _ = _map.insert($key, $value);
+            )*
+                _map
         }
     };
 }
@@ -87,6 +103,7 @@ macro_rules! hashmap {
 /// # }
 /// ```
 #[macro_export]
+#[cfg(feature = "hashbrown")]
 macro_rules! hashset {
     (@single $($x:tt)*) => (());
     (@count $($rest:expr),*) => (<[()]>::len(&[$(hashset!(@single $rest)),*]));
@@ -95,14 +112,28 @@ macro_rules! hashset {
     ($($key:expr),*) => {
         {
             let _cap = hashset!(@count $($key),*);
-            #[cfg(feature = "hashbrown")]
             let mut _set = ::hashbrown::HashSet::with_capacity(_cap);
-            #[cfg(not(feature = "hashbrown"))]
-            let mut _set = ::std::collections::HashSet::with_capacity(_cap);
             $(
                 let _ = _set.insert($key);
             )*
             _set
+        }
+    };
+}
+#[cfg(not(feature = "hashbrown"))]
+macro_rules! hashset {
+    (@single $($x:tt)*) => (());
+    (@count $($rest:expr),*) => (<[()]>::len(&[$(hashset!(@single $rest)),*]));
+
+    ($($key:expr,)+) => { hashset!($($key),+) };
+    ($($key:expr),*) => {
+        {
+            let _cap = hashset!(@count $($key),*);
+            let mut _set = ::std::collections::HashSet::with_capacity(_cap);
+            $(
+                let _ = _set.insert($key);
+            )*
+                _set
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,16 @@
 #[cfg(feature = "hashbrown")]
 extern crate hashbrown;
 
-#[macro_export]
+#[cfg(feature = "hashbrown")]
+pub type HashMap<A, B> = hashbrown::HashMap<A, B>;
+#[cfg(not(feature = "hashbrown"))]
+pub type HashMap<A, B> = std::collections::HashMap<A, B>;
+
+#[cfg(feature = "hashbrown")]
+pub type HashSet<A> = hashbrown::HashSet<A>;
+#[cfg(not(feature = "hashbrown"))]
+pub type HashSet<A> = std::collections::HashSet<A>;
+
 /// Create a **HashMap** from a list of key-value pairs
 ///
 /// ## Example
@@ -50,7 +59,7 @@ extern crate hashbrown;
 /// assert_eq!(map.get("c"), None);
 /// # }
 /// ```
-#[cfg(feature = "hashbrown")]
+#[macro_export]
 macro_rules! hashmap {
     (@single $($x:tt)*) => (());
     (@count $($rest:expr),*) => (<[()]>::len(&[$(hashmap!(@single $rest)),*]));
@@ -59,29 +68,11 @@ macro_rules! hashmap {
     ($($key:expr => $value:expr),*) => {
         {
             let _cap = hashmap!(@count $($key),*);
-            let mut _map = ::hashbrown::HashMap::with_capacity(_cap);
+            let mut _map = $crate::HashMap::with_capacity(_cap);
             $(
                 let _ = _map.insert($key, $value);
             )*
             _map
-        }
-    };
-}
-
-#[cfg(not(feature = "hashbrown"))]
-macro_rules! hashmap {
-    (@single $($x:tt)*) => (());
-    (@count $($rest:expr),*) => (<[()]>::len(&[$(hashmap!(@single $rest)),*]));
-
-    ($($key:expr => $value:expr,)+) => { hashmap!($($key => $value),+) };
-    ($($key:expr => $value:expr),*) => {
-        {
-            let _cap = hashmap!(@count $($key),*);
-            let mut _map = ::std::collections::HashMap::with_capacity(_cap);
-            $(
-                let _ = _map.insert($key, $value);
-            )*
-                _map
         }
     };
 }
@@ -103,7 +94,6 @@ macro_rules! hashmap {
 /// # }
 /// ```
 #[macro_export]
-#[cfg(feature = "hashbrown")]
 macro_rules! hashset {
     (@single $($x:tt)*) => (());
     (@count $($rest:expr),*) => (<[()]>::len(&[$(hashset!(@single $rest)),*]));
@@ -112,28 +102,11 @@ macro_rules! hashset {
     ($($key:expr),*) => {
         {
             let _cap = hashset!(@count $($key),*);
-            let mut _set = ::hashbrown::HashSet::with_capacity(_cap);
+            let mut _set = $crate::HashSet::with_capacity(_cap);
             $(
                 let _ = _set.insert($key);
             )*
             _set
-        }
-    };
-}
-#[cfg(not(feature = "hashbrown"))]
-macro_rules! hashset {
-    (@single $($x:tt)*) => (());
-    (@count $($rest:expr),*) => (<[()]>::len(&[$(hashset!(@single $rest)),*]));
-
-    ($($key:expr,)+) => { hashset!($($key),+) };
-    ($($key:expr),*) => {
-        {
-            let _cap = hashset!(@count $($key),*);
-            let mut _set = ::std::collections::HashSet::with_capacity(_cap);
-            $(
-                let _ = _set.insert($key);
-            )*
-                _set
         }
     };
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,7 @@
 
+#[cfg(feature = "hashbrown")]
+extern crate hashbrown;
+
 #[macro_use] extern crate maplit;
 
 #[test]


### PR DESCRIPTION
This adds `hashbrown` as a feature flag to allow using maplit with the [hashbrown](https://github.com/Amanieu/hashbrown) crate.