### PR TITLE
Support using the macros through full paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,19 @@ sudo: false
 matrix:
   include:
     - rust: 1.14.0
-    - rust: 1.20.0
+    - rust: 1.30.1
+    - rust: 1.37.0
+      env:
+        - TEST_ED2018=1
     - rust: stable
+      env:
+        - TEST_ED2018=1
     - rust: beta
+      env:
+        - TEST_ED2018=1
     - rust: nightly
+      env:
+        - TEST_ED2018=1
 branches:
   only:
     - master
@@ -15,4 +24,8 @@ script:
       cargo build --verbose --features "$FEATURES" &&
       cargo test --verbose --features "$FEATURES" &&
       ([ "$BENCH" != 1 ] || cargo bench --verbose --features "$FEATURES") &&
-      cargo doc --verbose --features "$FEATURES"
+      cargo doc --verbose --features "$FEATURES" &&
+      (cd rust2015user/; cargo build -v ) &&
+      if [ -n "$TEST_ED2018" ]; then
+        (cd rust2018user/; cargo build -v );
+      fi

--- a/rust2015user/Cargo.toml
+++ b/rust2015user/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust2015user"
+version = "0.1.0"
+authors = ["bluss"]
+publish = false
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+maplit = { version = "*", path = ".." }

--- a/rust2015user/src/lib.rs
+++ b/rust2015user/src/lib.rs
@@ -1,0 +1,15 @@
+#[macro_use(hashset)]
+extern crate maplit;
+
+pub mod test2 {
+    use std::collections::HashSet;
+
+    pub fn make_map() -> HashSet<String> {
+        let s = String::from;
+        hashset! {
+            s("a1"),
+            s("a2"),
+        }
+    }
+
+}

--- a/rust2018user/Cargo.toml
+++ b/rust2018user/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust2018user"
+version = "0.1.0"
+authors = ["bluss"]
+edition = "2018"
+publish = false
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+maplit = { version = "*", path = ".." }

--- a/rust2018user/src/lib.rs
+++ b/rust2018user/src/lib.rs
@@ -1,0 +1,28 @@
+pub mod test1 {
+    use std::collections::HashSet;
+
+    pub fn make_map() -> HashSet<String> {
+        let s = String::from;
+        maplit::hashset! {
+            s("a1"),
+            s("a2"),
+        }
+    }
+}
+
+pub mod test2 {
+    use maplit::hashset;
+    use std::collections::HashSet;
+
+    pub fn make_map() -> HashSet<String> {
+        let s = String::from;
+        hashset! {
+            s("a1"),
+            s("a2"),
+        }
+    }
+
+    pub fn convert() -> HashSet<String> {
+        maplit::convert_args!(hashset!("a", "b"))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,8 @@ pub fn __id<T>(t: T) -> T { t }
 ///
 /// [`Into`]: https://doc.rust-lang.org/std/convert/trait.Into.html
 ///
+/// **Note** To use `convert_args`, the macro that is being wrapped
+/// must itself be brought into the current scope with `#[macro_use]` or `use`.
 ///
 /// # Examples
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! Generic container macros already exist elsewhere, so those are not provided
 //! here at the moment.
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 /// Create a **HashMap** from a list of key-value pairs
 ///
 /// ## Example
@@ -74,7 +74,7 @@ macro_rules! hashmap {
 /// assert!(!set.contains("c"));
 /// # }
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! hashset {
     (@single $($x:tt)*) => (());
     (@count $($rest:expr),*) => (<[()]>::len(&[$(hashset!(@single $rest)),*]));
@@ -92,7 +92,7 @@ macro_rules! hashset {
     };
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 /// Create a **BTreeMap** from a list of key-value pairs
 ///
 /// ## Example
@@ -125,7 +125,7 @@ macro_rules! btreemap {
     };
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 /// Create a **BTreeSet** from a list of elements.
 ///
 /// ## Example
@@ -214,7 +214,7 @@ pub fn __id<T>(t: T) -> T { t }
 ///
 /// # }
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! convert_args {
     (keys=$kf:expr, $macro_name:ident !($($k:expr),* $(,)*)) => {
         $macro_name! { $(($kf)($k)),* }


### PR DESCRIPTION
This fixes the usage of hashmap, hashset, btreemap, btreeset, convert_args through paths, like for example `maplit::hashmap! {}`.

It is backwards compatible using a newish option on macro_export.

We don't solve the problems with convert_args at this time - instead add docs -- we'd like to support wrapping a macro with a path, but macros don't allow following a matcher of type `path` with `!`, so unsure what we can do.

Fixes #24 